### PR TITLE
Use Document_List instead of Document_Page::getList to load documents

### DIFF
--- a/lib/ElasticSearch/Job/CacheAllPagesJob.php
+++ b/lib/ElasticSearch/Job/CacheAllPagesJob.php
@@ -3,6 +3,7 @@
 namespace ElasticSearch\Job;
 
 use Document_Page;
+use Document_List;
 use ElasticSearch\Repository\PageRepository;
 use Exception;
 use Logger;
@@ -47,13 +48,13 @@ class CacheAllPagesJob
     {
         $documentCount = Document_Page::getTotalCount();
 
-        for ($documentIndex = 0; $documentIndex < $documentCount; $documentIndex += self::PAGE_PROCESSING_LIMIT) {
-            $documents = Document_Page::getList([
-                "limit" => self::PAGE_PROCESSING_LIMIT,
-                "offset" => $documentIndex
-            ]);
+        for ($documentIndex = 0; $documentIndex < $documentCount; $documentIndex = $documentIndex + self::PAGE_PROCESSING_LIMIT) {
+            $documentListing = new Document_List();
+            $documentListing->setOffset($documentIndex);
+            $documentListing->setLimit(self::PAGE_PROCESSING_LIMIT);
+            $documentListing->setCondition("type = ?", [ "page" ]);
 
-            foreach ($documents as $document) {
+            foreach ($documentListing->load() as $document) {
                 if ($document instanceof Document_Page && $document->isPublished()) {
                     $this->rebuildDocumentCache($document);
                 }

--- a/lib/ElasticSearch/Job/CacheAllPagesJob.php
+++ b/lib/ElasticSearch/Job/CacheAllPagesJob.php
@@ -48,7 +48,7 @@ class CacheAllPagesJob
     {
         $documentCount = Document_Page::getTotalCount();
 
-        for ($documentIndex = 0; $documentIndex < $documentCount; $documentIndex = $documentIndex + self::PAGE_PROCESSING_LIMIT) {
+        for ($documentIndex = 0; $documentIndex < $documentCount; $documentIndex += self::PAGE_PROCESSING_LIMIT) {
             $documentListing = new Document_List();
             $documentListing->setOffset($documentIndex);
             $documentListing->setLimit(self::PAGE_PROCESSING_LIMIT);


### PR DESCRIPTION
seems to be caused by a weird Pimcore bug. Document_List is more reliable.
